### PR TITLE
Allow Websocket provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function HDWalletProvider(
 
   this.engine.addProvider(new FiltersSubprovider());
   if (typeof provider === 'string') {
-    this.engine.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(provider)));
+    this.engine.addProvider(new ProviderSubprovider(new Web3.providers.WebsocketProvider(provider_url)));
   } else {
     this.engine.addProvider(new ProviderSubprovider(provider));
   }


### PR DESCRIPTION
Currently, truffle-hdwallet-provider only works with HttpProvider, this commit updates it to allow Websocket providers